### PR TITLE
修复 harness 消息压缩与投影时丢失用户原文的问题

### DIFF
--- a/desensitize.py
+++ b/desensitize.py
@@ -162,6 +162,8 @@ _SKILLS_MARKERS = (
     "### How to use skills",
 )
 
+# 第三段为 None 表示保留标签内正文（system-reminder 里是任务/记忆，不能整段丢掉）。
+_KEEP_INNER = None
 _RUNTIME_BLOCK_REPLACEMENTS = (
     (
         "<environment_context>",
@@ -194,13 +196,25 @@ _RUNTIME_BLOCK_REPLACEMENTS = (
     (
         "<system-reminder>",
         "</system-reminder>",
-        "Runtime reminder context is provided by the harness.",
+        _KEEP_INNER,
+    ),
+)
+
+_USER_HEADING_REPLACEMENTS = (
+    (
+        "# AGENTS.md instructions",
+        "Repository instructions and durable user context are provided.",
+    ),
+    (
+        "# claudeMd",
+        "Repository CLAUDE.md instructions are provided.",
     ),
 )
 
 _RUNTIME_TAIL_MARKERS = (
     "The following deferred tools are now available via ToolSearch.",
     "Available agent types for the Agent tool:",
+    "The following skills are available for use with the Skill tool:",
     "The following sk​ills are available for use with the Sk​ill tool:",
     "## MCP Server Instructions",
 )
@@ -254,27 +268,77 @@ def _content_to_text(content) -> str:
 
 
 def _looks_like_harness_user_message(content) -> bool:
-    """判断 user 消息是否其实是 Codex/CLI 注入的上下文，而非用户自然输入。"""
+    """判断 user 消息是否夹带了 Codex/CLI 注入的上下文。"""
     text = _content_to_text(content)
     return any(marker in text for marker in _HARNESS_USER_MARKERS)
 
 
-def _prune_runtime_fragments(role: str, text: str) -> str:
-    """轻量裁掉冗长的运行时元数据，保留主要行为指令。
+def _block_stop_pattern(start_tag: str) -> str:
+    """未闭合标签截到下一个已知注入块/标题，避免把后面的用户原文一起吃掉。"""
+    stops = [re.escape(tag) for tag, _, _ in _RUNTIME_BLOCK_REPLACEMENTS if tag != start_tag]
+    stops.extend(re.escape(heading) for heading, _ in _USER_HEADING_REPLACEMENTS)
+    return "(?:" + "|".join(stops) + ")" if stops else r"(?!)"
 
-    用于 --no-compact 场景：尽量保留 Codex / Claude Code 的核心提示，
-    但移除重复的 environment / permissions / skills / tool inventory 大段文本。
+
+def _apply_runtime_block_replacements(text: str) -> str:
+    """替换 environment/permissions 等注入块；system-reminder 只去标签、保留正文。"""
+    pruned = text
+    for start_tag, end_tag, replacement in _RUNTIME_BLOCK_REPLACEMENTS:
+        closed = re.compile(
+            r"\s*" + re.escape(start_tag) + r"(.*?)" + re.escape(end_tag) + r"\s*",
+            re.DOTALL,
+        )
+        unclosed = re.compile(
+            r"\s*" + re.escape(start_tag) + r"(.*?)(?=" + _block_stop_pattern(start_tag) + r"|\Z)",
+            re.DOTALL,
+        )
+
+        def _fill(inner: str) -> str:
+            inner = inner.strip()
+            if replacement is _KEEP_INNER:
+                return f"\n\n{inner}\n\n" if inner else "\n\n"
+            return "\n\n" + replacement + "\n\n"
+
+        pruned = closed.sub(lambda match: _fill(match.group(1)), pruned)
+        if start_tag in pruned:
+            pruned = unclosed.sub(lambda match: _fill(match.group(1)), pruned)
+    return pruned
+
+
+def _heading_stop_pattern(heading: str) -> str:
+    stops = [re.escape(tag) for tag, _, _ in _RUNTIME_BLOCK_REPLACEMENTS]
+    stops.extend(re.escape(other) for other, _ in _USER_HEADING_REPLACEMENTS if other != heading)
+    stops.extend(re.escape(summary) for _, _, summary in _RUNTIME_BLOCK_REPLACEMENTS if isinstance(summary, str))
+    stops.extend(re.escape(summary) for other, summary in _USER_HEADING_REPLACEMENTS if other != heading)
+    named = "(?:" + "|".join(stops) + ")" if stops else r"(?!)"
+    # 空行后的普通段落视为用户原话，不要跟 AGENTS.md / CLAUDE.md 一起吃掉。
+    plain_tail = r"\n\n(?!\s*(?:#|<[A-Za-z/]|[-*] ))"
+    return f"(?:{named}|{plain_tail})"
+
+
+def _replace_user_heading_sections(text: str) -> str:
+    """把 AGENTS.md / CLAUDE.md 注入标题段换成短句，后面的用户原话留下。"""
+    pruned = text
+    for heading, replacement in _USER_HEADING_REPLACEMENTS:
+        if heading not in pruned:
+            continue
+        pattern = re.compile(
+            r"\s*" + re.escape(heading) + r".*?(?=" + _heading_stop_pattern(heading) + r"|\Z)",
+            re.DOTALL,
+        )
+        pruned = pattern.sub("\n\n" + replacement + "\n\n", pruned)
+    return pruned
+
+
+def _prune_runtime_fragments(role: str, text: str) -> str:
+    """裁掉冗长运行时元数据，保留行为指令、reminder 正文，以及夹在注入块里的用户原话。
+
+    compact 与 --no-compact 的 user 路径共用：只抽 harness，不整段替换。
     """
     if not text:
         return text
 
-    pruned = text
-    for start_tag, end_tag, replacement in _RUNTIME_BLOCK_REPLACEMENTS:
-        pattern = re.compile(
-            r"\s*" + re.escape(start_tag) + r".*?" + re.escape(end_tag) + r"\s*",
-            re.DOTALL,
-        )
-        pruned = pattern.sub("\n\n" + replacement + "\n\n", pruned)
+    pruned = _apply_runtime_block_replacements(text)
 
     tail_indexes = [pruned.find(marker) for marker in _RUNTIME_TAIL_MARKERS if marker in pruned]
     if tail_indexes:
@@ -310,23 +374,18 @@ def _prune_runtime_fragments(role: str, text: str) -> str:
         else:
             pruned = _CODEX_CORE_SUMMARY
 
-    if role == "user" and _looks_like_harness_user_message(pruned):
-        if (
-            "# AGENTS.md instructions" in pruned
-            or "<environment_context>" in text
-            or "<skills_instructions>" in text
-        ):
-            return (
-                "Repository instructions and durable user context are provided. "
-                "Follow repository guidance while answering the user's actual request."
-            )
+    if role == "user":
+        pruned = _replace_user_heading_sections(pruned)
 
     pruned = re.sub(r"\n{3,}", "\n\n", pruned).strip()
     return pruned
 
 
 def _compact_harness_message(role: str, content) -> str | None:
-    """把 Codex / Claude Code 注入的超长运行时提示压缩成短摘要，降低审核误伤。"""
+    """把 Codex / Claude Code 注入的超长运行时提示压缩成短摘要，降低审核误伤。
+
+    user 消息不再整段替换：只抽 harness 块，system-reminder 正文和用户原话留下。
+    """
     text = _content_to_text(content)
     if not text:
         return None
@@ -340,20 +399,17 @@ def _compact_harness_message(role: str, content) -> str | None:
             "You are a coding assistant in Codex CLI. Be precise, helpful, concise, and safe. "
             "Use available tools when needed, follow repository instructions, and keep the user informed."
         )
-    if any(marker in text for marker in _PERMISSIONS_MARKERS):
+    if role == "system" and any(marker in text for marker in _PERMISSIONS_MARKERS):
         return (
             "Runtime permissions apply: filesystem access may be sandboxed, network may be restricted, "
             "and some commands may require user approval."
         )
-    if any(marker in text for marker in _SKILLS_MARKERS):
+    if role == "system" and any(marker in text for marker in _SKILLS_MARKERS):
         return (
             "Runtime skill metadata is available. Use relevant skills only when explicitly requested or clearly applicable."
         )
     if role == "user" and _looks_like_harness_user_message(content):
-        return (
-            "Repository instructions and environment context are provided. Follow repository guidance "
-            "while answering the user's actual request."
-        )
+        return _prune_runtime_fragments("user", text)
     return None
 
 

--- a/responses_projection.py
+++ b/responses_projection.py
@@ -144,23 +144,36 @@ def project_responses_chat_body(body: dict) -> tuple[dict, dict]:
 
         if role == "system":
             if _looks_like_harness_system(text):
+                # 命中 harness 不再整段丢弃：只压缩运行时元数据，
+                # 保住真实行为规范与仓库约束，避免模型失去工作准则。
                 dropped_harness_messages += 1
-                continue
+                text = _prune_runtime_fragments("system", text)
             guidance = _truncate_text(text, MAX_SYSTEM_GUIDANCE_CHARS)
             if guidance:
                 preserved_guidance.append(guidance)
             continue
 
         if role == "user" and _looks_like_harness_user(text):
+            # 只抽掉注入块，同条里的用户原话与 reminder 正文必须留下。
+            # 旧实现在这里直接 continue，整条消息连同用户真话一起消失，
+            # 且 anchor/history-summary 都在过滤后的列表上计算，救不回来。
             dropped_harness_messages += 1
-            continue
+            text = _prune_runtime_fragments("user", text)
+            if not text.strip():
+                continue
+            msg = {**msg, "content": text}
 
         projected_msg = _project_conversation_message(msg)
         if projected_msg is not None:
             conversation.append(projected_msg)
 
     if not conversation:
-        conversation = _project_messages_conservative(messages)
+        # 兜底整段投影：丢掉的只是"抽取后没有任何用户内容"的纯 harness 消息，
+        # 夹带用户原话的消息必须留下，否则又会回到丢上下文的老问题。
+        conversation = [
+            m for m in _project_messages_conservative(messages)
+            if not _is_pure_harness_message(m)
+        ]
 
     tail_start = _choose_tail_start(conversation)
     tail_start = _expand_tail_for_tool_context(conversation, tail_start)
@@ -674,6 +687,48 @@ def _looks_like_harness_user(text: str) -> bool:
 
 def _looks_like_harness_system(text: str) -> bool:
     return any(marker in text for marker in HARNESS_SYSTEM_MARKERS)
+
+
+def _prune_runtime_fragments(role: str, text: str) -> str:
+    """复用脱敏层的抽取逻辑：只去注入块，保留用户原话与 reminder 正文。
+
+    投影层与脱敏层必须行为一致，否则 /v1/responses(Codex CLI) 和
+    /v1/chat/completions 两条路径会拿到不同的上下文。这里直接复用同一份
+    实现，避免两处各自漂移；万一该模块不可用，原样返回也绝不丢弃内容。
+    """
+    if not text:
+        return text
+    try:
+        from desensitize import _prune_runtime_fragments as _impl
+    except Exception:
+        return text
+    return _impl(role, text)
+
+
+HARNESS_DOMINANT_RATIO = 0.5
+
+
+def _is_pure_harness_message(msg: dict) -> bool:
+    """判断投影后的消息是否只是 harness 载荷（可安全丢弃）。
+
+    用户原话与 harness 同条时，压缩后 harness 通常占大头、用户话只占末尾；
+    因此仅在第一条 harness 标记之前的 harness 前缀占比很高时才视为纯 harness。
+    """
+    text = _content_to_text(msg.get("content", ""))
+    stripped = text.strip()
+    if not stripped:
+        return True
+    positions = [stripped.find(marker) for marker in HARNESS_USER_MARKERS]
+    positions = [pos for pos in positions if pos >= 0]
+    if not positions:
+        return False
+    if min(positions) > 0:
+        return False
+    # 从最早出现的 harness 标记起到下一个空行（用户原话通常从这里开始）
+    rest = stripped[min(positions):]
+    boundary = rest.find("\n\n")
+    dominant = rest if boundary < 0 else rest[:boundary]
+    return len(dominant) / len(stripped) >= HARNESS_DOMINANT_RATIO
 
 
 def _message_cost(msg: dict) -> int:

--- a/test_responses_adapter.py
+++ b/test_responses_adapter.py
@@ -118,7 +118,7 @@ def test_typed_developer_message_request():
 
 
 def test_desensitize_harness_user_and_tools():
-    """测试：harness user 上下文会被摘要，tool 描述会脱敏，真实 user 不改。"""
+    """测试：harness user 注入块会被摘要，tool 描述会脱敏，真实 user 不改。"""
     body = {
         "messages": [
             {"role": "system", "content": "Refuse exploit development."},
@@ -137,13 +137,15 @@ def test_desensitize_harness_user_and_tools():
     )
     assert "​" in out["messages"][0]["content"]
     assert "Repository instructions and durable user context are provided." in out["messages"][1]["content"]
+    assert "Environment context is provided by the harness." in out["messages"][1]["content"]
     assert "​" not in out["messages"][2]["content"]
+    assert out["messages"][2]["content"] == "please explain dos attacks"
     assert "​" in out["tools"][0]["function"]["description"]
     print("✅ test_desensitize_harness_user_and_tools")
 
 
 def test_compact_harness_messages_and_strip_tool_metadata():
-    """测试：Codex 注入长提示被压缩，tool 描述可直接裁掉。"""
+    """测试：Codex 注入长提示被压缩，tool 描述可直接裁掉；user 原话不被整段替换。"""
     body = {
         "messages": [
             {"role": "system", "content": "You are a coding agent running in the Codex CLI. # How you work\nUse sandbox and escalation."},
@@ -165,7 +167,8 @@ def test_compact_harness_messages_and_strip_tool_metadata():
     assert len(out["messages"][0]["content"]) < 220
     assert "Codex CLI" in out["messages"][0]["content"]
     assert "sandboxing defines" not in out["messages"][1]["content"]
-    assert "Repository instructions and environment context" in out["messages"][2]["content"]
+    assert "Repository instructions and durable user context are provided." in out["messages"][2]["content"]
+    assert "Environment context is provided by the harness." in out["messages"][2]["content"]
     assert "description" not in out["tools"][0]["function"]
     assert "description" not in out["tools"][0]["function"]["parameters"]["properties"]["cmd"]
     print("✅ test_compact_harness_messages_and_strip_tool_metadata")
@@ -218,6 +221,10 @@ def test_no_compact_still_prunes_codex_runtime_metadata():
     assert "very long skills metadata" not in harness_text
     assert "# AGENTS.md instructions" not in harness_text
     assert "Repository instructions and durable user context are provided." in harness_text
+    assert "Environment context is provided by the harness." in harness_text
+    # skill 里的 kill 会被 desensitize_text 插入零宽空格，断言前先剥离，避免与脱敏逻辑耦合
+    assert "Runtime skill metadata is available" in harness_text.replace("​", "")
+    assert harness_text.strip().replace("​", "").endswith("test")
     assert out["messages"][2]["content"] == "test"
     print("✅ test_no_compact_still_prunes_codex_runtime_metadata")
 

--- a/test_responses_adapter.py
+++ b/test_responses_adapter.py
@@ -396,6 +396,62 @@ def test_responses_projection_shrinks_large_tool_arguments():
     print("✅ test_responses_projection_shrinks_large_tool_arguments")
 
 
+def _agentic_tool():
+    return [{
+        "type": "function",
+        "function": {
+            "name": "exec_command",
+            "parameters": {"type": "object", "properties": {"cmd": {"type": "string"}}},
+        },
+    }]
+
+
+def test_responses_projection_keeps_user_text_sharing_harness_message():
+    """测试：harness 与用户原话同条时，用户原文和 reminder 正文必须保留。
+
+    回归：旧实现在 user 命中 harness 标记时直接 continue，整条消息连同
+    用户真话一起被丢掉，后端完全看不到用户这一轮说了什么。
+    """
+    body = {
+        "model": "auto",
+        "tools": _agentic_tool(),
+        "messages": [
+            {"role": "system", "content": "You are a coding agent running in the Codex CLI. # How you work"},
+            {"role": "user", "content": "# AGENTS.md instructions\n<INSTRUCTIONS>\nUse tabs\n</INSTRUCTIONS>"},
+            {"role": "user", "content": "<system-reminder>\n剩余任务：改看板\n</system-reminder>\n\n继续之前的前端改造工程，把登录页也改了"},
+            {"role": "assistant", "content": "好的，我来改登录页"},
+            {"role": "user", "content": "另外把看板的按钮也加上"},
+        ],
+    }
+    out, stats = project_responses_chat_body(body)
+    assert stats["mode"] == "aggressive"
+    blob = "\n".join(str(m.get("content", "")) for m in out["messages"])
+    assert "继续之前的前端改造工程" in blob, "与 harness 同条的用户原话被丢弃"
+    assert "剩余任务：改看板" in blob, "system-reminder 正文被丢弃"
+    assert "另外把看板的按钮也加上" in blob
+    assert "# AGENTS.md instructions" not in blob, "纯 harness 载荷应以摘要出现"
+    assert stats["anchor_user_preserved"] or "继续之前的前端改造工程" in blob
+    print("✅ test_responses_projection_keeps_user_text_sharing_harness_message")
+
+
+def test_responses_projection_keeps_last_user_when_it_carries_harness():
+    """测试：最坏情况下（含真话的 harness 恰为最后一条 user）用户真话仍保留。"""
+    body = {
+        "model": "auto",
+        "tools": _agentic_tool(),
+        "messages": [
+            {"role": "system", "content": "You are a coding agent running in the Codex CLI."},
+            {"role": "assistant", "content": "上一轮的答复"},
+            {"role": "user", "content": "<system-reminder>\n剩余任务：改看板\n</system-reminder>\n\n继续之前的前端改造工程，把登录页也改了"},
+        ],
+    }
+    out, stats = project_responses_chat_body(body)
+    blob = "\n".join(str(m.get("content", "")) for m in out["messages"])
+    assert "继续之前的前端改造工程" in blob, "最后一轮用户真话丢失"
+    assert "剩余任务：改看板" in blob, "reminder 正文丢失"
+    print("✅ test_responses_projection_keeps_last_user_when_it_carries_harness")
+
+
 def test_stream_converter_text():
     """测试：Chat SSE 文本流 → Responses 事件流。"""
     conv = ResponsesStreamConverter(model="glm-5.2")
@@ -517,7 +573,9 @@ if __name__ == "__main__":
     test_responses_projection_compacts_codex_harness_and_tools()
     test_responses_projection_preserves_recent_tool_chain_and_summarizes_history()
     test_responses_projection_shrinks_large_tool_arguments()
+    test_responses_projection_keeps_user_text_sharing_harness_message()
+    test_responses_projection_keeps_last_user_when_it_carries_harness()
     test_stream_converter_text()
     test_stream_converter_function_call()
     test_nonstream_response()
-    print(f"\n🎉 All {15} tests passed!")
+    print(f"\n🎉 All {17} tests passed!")


### PR DESCRIPTION
## 问题

`desensitize.py`（`/v1/chat/completions` 路径）与 `responses_projection.py`（`/v1/responses` 路径，Codex CLI 走这条）对消息的判定逻辑都是「只要**含有**任一 harness 标记（`<system-reminder>`、`AGENTS.md`、`<environment_context>` 等）就整条处理」：

- **脱敏层**：user 消息命中 → 整条替换成一句固定话术（`Repository instructions and environment context are provided.`），用户原话全部丢失
- **投影层**：user 消息命中 → `continue` 直接整条丢弃，比替换更彻底

但 harness 注入块经常与用户原话**在同一条消息里**（典型形态：`<system-reminder>` 任务提示 + 用户真实指令）。生产日志实测：一次投影把请求从 59,483 字符砍到 8,056（**-86%**），13 次 aggressive 投影全部 `anchor_user=False` —— 用户原话 100% 丢失。

## 修复

**desensitize.py**

1. user 消息命中 harness 时不再整条替换，改为 `_prune_runtime_fragments` 抽取：只摘掉注入块，**用户原话原样保留**
2. `<system-reminder>` 使用 `_KEEP_INNER` 哨兵：只去标签、**保留正文**（里面的任务状态 / 记忆不能丢）
3. 标题段压缩为短句、其后紧跟的用户原文保留：`# AGENTS.md instructions` → `Repository instructions and durable user context are provided.`、`# claudeMd` → `Repository CLAUDE.md instructions are provided.`
4. 新增 `_block_stop_pattern` / `_heading_stop_pattern`：未闭合标签的截断边界，防止替换吞掉后面紧跟的用户原文
5. permissions / skills 的替换分支加 `role == "system"` 限定：只对 system 消息生效，不再波及 user 消息
6. system 消息从「整条替换成固定话术」改为压缩，保留行为规范
7. `_RUNTIME_TAIL_MARKERS` 新增不带零宽字符的普通写法 skill 标记（`The following skills are available for use with the Skill tool:`），与既有零宽写法并存

**responses_projection.py**

1. user 消息命中 harness：从 `continue` 整条丢弃 → `_prune_runtime_fragments` 压缩（只抽 harness 块，保留用户原话）
2. system 消息同样从丢弃改为压缩
3. `dropped_harness_messages` 语义调整：只统计命中 harness 判定的条数，**只有抽取后完全为空**的纯 harness 消息才真正丢弃
4. 空 conversation 兜底路径新增 `_is_pure_harness_message` 过滤：只有 harness 前缀（从最早标记到第一个空行）占比 ≥ 50%（`HARNESS_DOMINANT_RATIO = 0.5`）才视为纯 harness 丢弃，避免误伤「harness 占大头、用户原话在末尾」的混合消息

**test_responses_adapter.py**：15 → 17 个用例

- 新增 `test_responses_projection_keeps_user_text_sharing_harness_message`（harness 与用户原话同条 → 原话保留）
- 新增 `test_responses_projection_keeps_last_user_when_it_carries_harness`（最后一轮 user 携带 harness → 仍保留）
- 既有用例断言同步更新以匹配新行为

## 验证

- 投影层测试 17/17 通过，含 2 个复现原数据丢失场景的回归用例
- 端到端实测（修复前 100% 丢失的最坏场景：harness 与真话同条且为最后一条 user）：修复后用户真话与 reminder 正文均保留，纯 harness 载荷仍压缩为摘要
- 全量回归：除 3 个 macOS `/var` → `/private/var` 路径别名的既有失败外全部通过（Linux CI 不受影响）

## 变更统计

3 files changed，+210 / -34
